### PR TITLE
to_zelig_mi now accepts a list of data.frames in addition data.frames as separate arguments 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -263,7 +263,7 @@ expand_grid_setrange <- function(x) {
 #'   \code{zelig}.
 #' @note This function creates a list of \code{data.frame} objects, which
 #'   resembles the storage of imputed data sets in the \code{amelia} object.
-#' @param ... a set of \code{data.frame}'s
+#' @param ... a set of \code{data.frame}'s or a single list of \code{data.frame}'s
 #' @return an \code{mi} object composed of a list of data frames.
 #' @author Matt Owen, James Honaker, and Christopher Gandrud
 #' @export
@@ -287,9 +287,16 @@ to_zelig_mi <- function (...) {
 
     # Get arguments as list
     imputations <- list(...)
-    names(imputations) <- paste("imp", 1:length(imputations), sep = "")
 
-      # Ensure that everything is data.frame
+    # If user passes a list of data.frames rather than several data.frames as separate arguments
+    if((class(imputations[[1]]) == 'list') & (length(imputations) == 1)){
+        imputations = imputations[[1]]
+    }   
+
+    # Labelling
+    names(imputations) <- paste0("imp", 1:length(imputations))
+
+    # Ensure that everything is data.frame
     for (k in length(imputations):1) {
         if (!is.data.frame(imputations[[k]])){
             imputations[[k]] <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -404,7 +404,12 @@ strip_package_name <- function(x) {
 #' @internal
 
 p_pull <- function(x) {
-    p_values <- summary(x)$coefficients[, "Pr(>|t|)"]
+    p_values <- summary(x)$coefficients
+    if('Pr(>|t|)' %in% colnames(p_values)){
+        p_values <- p_values[, 'Pr(>|t|)']
+    }else{
+        p_values <- p_values[, 'Pr(>|z|)']
+    }
     return(p_values)
 }
 
@@ -413,8 +418,8 @@ p_pull <- function(x) {
 #' @internal
 
 se_pull <- function(x) {
-  p_values <- summary(x)$coefficients[, "Std. Error"]
-  return(p_values)
+  se <- summary(x)$coefficients[, "Std. Error"]
+  return(se)
 }
 
 #' Drop intercept columns from a data frame of fitted values

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -23,6 +23,23 @@ test_that('REQUIRE TEST for to_zelig_mi', {
     expect_equivalent(round(as.numeric(z.out$get_coef()[[1]][2]), 3), 0.1)
 })
 
+# REQUIRE TEST for to_zelig_mi -------------------------------------------------
+test_that('REQUIRE TEST for to_zelig_mi -- with list of data.frames', {
+    set.seed(123)
+    n <- 100
+    x1 <- runif(n)
+    x2 <- runif(n)
+    y <- rnorm(n)
+    data.1 <- data.frame(y = y, x = x1)
+    data.2 <- data.frame(y = y, x = x2)
+    data_mi = list(data.1, data.2)
+    
+    mi.out <- to_zelig_mi(data_mi)
+    z.out <- zelig(y ~ x, model = "ls", data = mi.out)
+    
+    expect_equivalent(round(as.numeric(z.out$get_coef()[[1]][2]), 3), 0.1)
+})
+
 # FAIL TESTS for to_zelig_mi ----------------------------------------------------
 test_that('FAIL TESTS for to_zelig_mi', {
     x <- 100


### PR DESCRIPTION
Use-case:

```
library(mice)
library(Zelig)
imp <- mice::mice(nhanes, m=5)
imp <- lapply(1:5, function(k) mice::complete(imp, k)) 
imp <- Zelig::to_zelig_mi(imp)
Zelig::zelig(age ~ hyp, data=imp, model='poisson')
```

I include a simple test, but the output of Zelig's testthat are pretty obscure to me, so I'm not sure everything's OK on that side.
