### PR TITLE
Fixes relogit's performance issue rooted in its `lm.influence` call

### DIFF
--- a/R/model-relogit.R
+++ b/R/model-relogit.R
@@ -256,7 +256,7 @@ relogit <- function(formula,
       }
       W <- pihat * (1 - pihat) * wi
       ##Qdiag <- diag(X%*%solve(t(X)%*%diag(W)%*%X)%*%t(X))
-      Qdiag <- lm.influence(lm(y ~ X - 1, weights = W))$hat / W
+      Qdiag <- lm.influence(lm(y ~ X - 1, weights = W), do.coef = FALSE)$hat / W
       if (is.null(tau)) # w_1=1 since tau=ybar
         xi <- 0.5 * Qdiag * (2 * pihat - 1)
       else


### PR DESCRIPTION
This patch fixes #88 by tweaking the output options of `lm.influence`. `lm.influence`'s default behaviour is to return a matrix of coefficient changes. It is computationally complex to calculate that matrix, what is slowing down the function call here. But we don't need that output, given that the `lm.influence` call here is only used to obtain the "hat" matrix. I simply switched that output off. The change doesn't have any bearing on calculation of the "hat" matrix.

ref: https://www.rdocumentation.org/packages/stats/versions/3.4.1/topics/lm.influence