### PR TITLE
Arima doc

### DIFF
--- a/vignettes/zelig_arima.Rmd
+++ b/vignettes/zelig_arima.Rmd
@@ -89,6 +89,20 @@ ts.out$sim()
 plot(ts.out)
 ```
 
+### AR and MA Models
+
+AR (Autoregressive) and MA (Moving Average) models are commonly used in time series analysis. As both AR and MA models are special cases of ARIMA models they are not implemented as separate models within Zelig. Specification of AR and MA models can be accomplished by changing the value of the `order` parameter within the ARIMA model.
+
+#### AR
+```{r, eval=FALSE}
+ts.out <- zelig(unemp ~ leftseat, model = "arima", order = c(1, 0, 0), data = subset)
+```
+#### MA
+```{r, eval=FALSE}
+ts.out <- zelig(unemp ~ leftseat, model = "arima", order = c(0, 0, 1), data = subset)
+```
+
+
 ### Multiple Series
 
 The dataset contains similar series for 11 different OECD countries, and we could run the same model on each country's data.  Here we need to specify the `ts` and `cs` arguments to identify the names of variables that give the time and cross-section of each observation in the dataset

--- a/vignettes/zelig_arima.Rmd
+++ b/vignettes/zelig_arima.Rmd
@@ -77,7 +77,7 @@ Summarize estimated model parameters:
 summary(ts.out)
 ```
 
-Next we simulate what happens when leftseat share drops from a moderately high level of 75 percent, to a rather low level of 25 percent:
+Next we simulate what happens when leftseat share drops from a moderately high level of 75 percent, to a rather low level of 25 percent. Note that the `setx` and `setx1` methods both must be called in order to be able to successfully plot the results of timeseries simulation:
 
 ```{r, eval = TRUE}
 ts.out$setx(leftseat = 0.75)


### PR DESCRIPTION
The `setx` and `setx1` methods both need to be called in order to successfully plot the results of time series models. Previously this was not documented. I added a line to the Arima vignette so this would be clear.